### PR TITLE
Fix missing headers and symbol registration

### DIFF
--- a/main/elf/esp_elf_symbol.c
+++ b/main/elf/esp_elf_symbol.c
@@ -150,7 +150,7 @@ struct dyn_esp_elfsym {
 static struct dyn_esp_elfsym *g_dyn_syms = NULL;
 
 /* Внутренняя реализация – добавление узла в список   */
-static uintptr_t _register_symbol(const char *name, void *sym)
+uintptr_t _register_symbol(const char *name, void *sym)
 {
     if (!name || !sym) {
         return 0;

--- a/main/exec.c
+++ b/main/exec.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include "elf/esp_elf.h"
+#include "esp_err.h"
 #include "esp_log.h"
 
 static const char *TAG = "launchpad";

--- a/main/exec.h
+++ b/main/exec.h
@@ -4,6 +4,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>   /* size_t */
+#include <stdint.h>   /* uint8_t */
 
 /**
  * @brief Запускает ELF из памяти.

--- a/main/init.c
+++ b/main/init.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include "elf/elf_symbol.h"
+#include "elf/esp_elf.h"
 #include "platform.h"
 
 void launchpad_init(void)


### PR DESCRIPTION
## Summary
- include `<stdint.h>` in exec API
- use esp-idf error definitions and register platform symbol
- expose `_register_symbol` for dynamic symbol registration

## Testing
- `idf.py build` *(command not found)*
- `cmake -S . -B build` *(missing /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a99b57dfa88327ac2ed8de13714a86