### PR TITLE
Fix ESP-IDF flash and SD API type conflicts

### DIFF
--- a/main/abi/launchpad/sd.c
+++ b/main/abi/launchpad/sd.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <stdint.h>
 #include <driver/gpio.h>
 #include <driver/spi_common.h>
 #include <esp_vfs_fat.h>
@@ -105,7 +106,7 @@ esp_err_t launchpad_sd_unmount(const char *mount_path)
         return ESP_ERR_INVALID_ARG;
     }
 
-    esp_err_t err = esp_vfs_fat_sdmmc_unmount(mount_path, s_card);
+    esp_err_t err = esp_vfs_fat_sdcard_unmount(mount_path, s_card);
     if (err == ESP_OK) {
         s_mounted  = false;
         s_card     = NULL;
@@ -153,8 +154,8 @@ size_t launchpad_sd_get_free_space_bytes(void)
 
 /* Низкоуровневый доступ: отправка произвольной команды SD */
 esp_err_t launchpad_sd_send_cmd(uint8_t cmd, uint32_t arg,
-                                sdmmc_response_type_t resp_type,
-                                sdmmc_response_t *resp)
+                                sdmmc_response_t resp_type,
+                                uint32_t *resp)
 {
     if (!s_mounted) return ESP_ERR_INVALID_STATE;
 

--- a/main/abi/posix/vfs/permission.c
+++ b/main/abi/posix/vfs/permission.c
@@ -83,6 +83,7 @@ int launchpad_set_permission(const char *path, mode_t mode)
     }
 
 
+/* Use VFS-specific chmod when available; otherwise fall back to ENOSYS */
 # ifdef CONFIG_VFS_SUPPORT
     /* В VFS API есть esp_vfs_chmod(). Если оно доступно – используем. */
 #  if defined(ESP_IDF_VERSION) && ESP_IDF_VERSION >= 50000   /* 5.x и выше */
@@ -104,5 +105,4 @@ int launchpad_set_permission(const char *path, mode_t mode)
     errno = ENOSYS;
     return -1;
 # endif
-#endif
 }

--- a/main/include/flash.h
+++ b/main/include/flash.h
@@ -11,18 +11,10 @@
 
 #include <stddef.h>
 #include <stdbool.h>
+#include <stdint.h>
 
-/* Forward declaration for the opaque handle returned by mmap */
-typedef uint32_t spi_flash_mmap_handle_t;
-
-/* The enum is defined by ESP-IDF – we just re‑export it here so callers
- * don't need to include esp_spi_flash.h directly.  If you prefer, simply
- * #include <esp_spi_flash.h> instead of this typedef.
- */
-typedef enum {
-    SPI_FLASH_MMAP_DATA = 0,
-    SPI_FLASH_MMAP_INST = 1
-} spi_flash_mmap_memory_t;
+/* Pull in the official ESP‑IDF definitions for SPI flash types/functions. */
+#include "esp_spi_flash.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/main/include/partition.h
+++ b/main/include/partition.h
@@ -18,14 +18,6 @@
 #include "esp_spi_flash.h"          /* for spi_flash_mmap_handle_t */
 #include "esp_flash_encrypt.h"
 
-/* ------------------------------------------------------------------
- *  Mapping memory type – re‑export the enum from esp_spi_flash.h
- * ------------------------------------------------------------------ */
-typedef enum {
-    SPI_FLASH_MMAP_DATA = 0,
-    SPI_FLASH_MMAP_INST = 1
-} spi_flash_mmap_memory_t;
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/main/include/sd.h
+++ b/main/include/sd.h
@@ -3,9 +3,10 @@
 #define LAUNCHPAD_SD_H_
 
 #include <stdbool.h>
+#include <stdint.h>
 #include "esp_err.h"
 #include "driver/gpio.h"      /* gpio_num_t, GPIO_NUM_* */
-#include "sdmmc_cmd.h"        /* sdmmc_card_t, sdmmc_response_type_t, SDMMC_FREQ_* */
+#include "sdmmc_cmd.h"        /* sdmmc_card_t, SDMMC_FREQ_* */
 
 typedef struct {
     const char *mount_path;
@@ -42,7 +43,7 @@ size_t launchpad_sd_get_free_space_bytes(void);
 
 /* Низкоуровневый доступ (команды) */
 esp_err_t launchpad_sd_send_cmd(uint8_t cmd, uint32_t arg,
-                                sdmmc_response_type_t resp_type,
-                                sdmmc_response_t *resp);
+                                sdmmc_response_t resp_type,
+                                uint32_t *resp);
 
 #endif /* LAUNCHPAD_SD_H_ */


### PR DESCRIPTION
## Summary
- rely on ESP-IDF headers for SPI flash types
- update SD card wrapper to new esp_vfs_fat API and response types
- tidy VFS permission helper macros

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3d673210832795ae1adb97a2097f