### PR TITLE
Update flash and SD APIs for ESP-IDF v5

### DIFF
--- a/main/abi/launchpad/flash.c
+++ b/main/abi/launchpad/flash.c
@@ -9,8 +9,9 @@
 #include "include/flash.h"
 
 #include <esp_log.h>
+#include "esp_flash.h"
+#include "spi_flash_mmap.h"
 #include "esp_flash_encrypt.h" /* esp_flash_encryption_enabled() */
-#include "esp_spi_flash.h"
 
 /* ------------------------------------------------------------------
  * Internal helper: Convert an ESP-IDF esp_err_t into 0 / non‑zero.
@@ -28,14 +29,21 @@ static const char *TAG = "LaunchpadFlashAPI";
 
 size_t launchpad_flash_size(void)
 {
-    /* The underlying function already returns the size in bytes. */
-    return spi_flash_get_chip_size();
+    uint32_t size = 0;
+    esp_err_t err = esp_flash_get_size(NULL, &size);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to get flash size: 0x%x", err);
+        return 0;
+    }
+    return size;
 }
 
 /* -------------------------------------------------------------- */
 int launchpad_flash_erase(size_t sector)
 {
-    esp_err_t status = spi_flash_erase_sector(sector);
+    esp_err_t status = esp_flash_erase_region(NULL,
+                                              sector * SPI_FLASH_SEC_SIZE,
+                                              SPI_FLASH_SEC_SIZE);
     if (status != ESP_OK) {
         ESP_LOGE(TAG, "Erase sector %zu failed: 0x%x", sector, status);
     }
@@ -45,7 +53,7 @@ int launchpad_flash_erase(size_t sector)
 /* -------------------------------------------------------------- */
 int launchpad_flash_erase_range(size_t start_address, size_t size)
 {
-    esp_err_t status = spi_flash_erase_range(start_address, size);
+    esp_err_t status = esp_flash_erase_region(NULL, start_address, size);
     if (status != ESP_OK) {
         ESP_LOGE(TAG,
                  "Erase range 0x%zx..0x%zx failed: 0x%x",
@@ -64,7 +72,7 @@ int launchpad_flash_read(size_t src_addr, void *dest, size_t size)
         return 1;
     }
 
-    esp_err_t status = spi_flash_read(src_addr, dest, size);
+    esp_err_t status = esp_flash_read(NULL, dest, src_addr, size);
     if (status != ESP_OK) {
         ESP_LOGE(TAG, "Read from 0x%zx failed: 0x%x", src_addr, status);
     }
@@ -81,7 +89,7 @@ int launchpad_flash_write(size_t dest_addr,
         return 1;
     }
 
-    esp_err_t status = spi_flash_write(dest_addr, src, size);
+    esp_err_t status = esp_flash_write(NULL, src, dest_addr, size);
     if (status != ESP_OK) {
         ESP_LOGE(TAG, "Write to 0x%zx failed: 0x%x", dest_addr, status);
     }
@@ -111,7 +119,7 @@ int launchpad_flash_write_encrypted(size_t dest_addr,
         return 1;
     }
 
-    esp_err_t status = spi_flash_write_encrypted(dest_addr, src, size);
+    esp_err_t status = esp_flash_write_encrypted(NULL, dest_addr, src, size);
     if (status != ESP_OK) {
         ESP_LOGE(TAG,
                  "Encrypted write to 0x%zx failed: 0x%x",

--- a/main/include/flash.h
+++ b/main/include/flash.h
@@ -14,7 +14,8 @@
 #include <stdint.h>
 
 /* Pull in the official ESP‑IDF definitions for SPI flash types/functions. */
-#include "esp_spi_flash.h"
+#include "esp_flash.h"
+#include "spi_flash_mmap.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/main/include/partition.h
+++ b/main/include/partition.h
@@ -15,7 +15,7 @@
 #include <stdbool.h>
 
 #include "esp_partition.h"
-#include "esp_spi_flash.h"          /* for spi_flash_mmap_handle_t */
+#include "spi_flash_mmap.h"          /* for spi_flash_mmap_handle_t */
 #include "esp_flash_encrypt.h"
 
 #ifdef __cplusplus

--- a/main/include/sd.h
+++ b/main/include/sd.h
@@ -43,7 +43,7 @@ size_t launchpad_sd_get_free_space_bytes(void);
 
 /* Низкоуровневый доступ (команды) */
 esp_err_t launchpad_sd_send_cmd(uint8_t cmd, uint32_t arg,
-                                sdmmc_response_t resp_type,
+                                int resp_type,
                                 uint32_t *resp);
 
 #endif /* LAUNCHPAD_SD_H_ */


### PR DESCRIPTION
## Summary
- switch SPI flash helpers to esp_flash APIs and new headers
- replace deprecated sdmmc_app_command with sdmmc_send_app_cmd wrapper
- update partition and SD headers to reflect new interfaces

## Testing
- `idf.py build` *(command not found)*
- `make` *(no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3f33bf288327b41464b05de87f17